### PR TITLE
fix: remove bottle:unneeded

### DIFF
--- a/lazynpm.rb
+++ b/lazynpm.rb
@@ -3,7 +3,6 @@ class Lazynpm < Formula
   desc "A simple terminal UI for git commands, written in Go"
   homepage "https://github.com/jesseduffield/lazynpm/"
   version "0.1.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/jesseduffield/lazynpm/releases/download/v0.1.4/lazynpm_0.1.4_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
For jesseduffield/lazynpm#8, this PR updates `lazynpm.rb` to be compatible with the latest versions of Homebrew.

Until this is merged, people can use `brew install jeremyckahn/lazynpm/lazynpm` to install lazynpm via Homebrew.

BTW, thanks for making lazynpm @jesseduffield! It's an indispensable tool for my day-to-day work.